### PR TITLE
Feature/gui buttons (mobile control for volume)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Most Denon models that are network control enabled through Telnet should work.
 * AVR-3808A
 * AVR-X4200W
 * AVR-X4000
+* AVR-X4100W
 * AVR-X5200
 * AVR-X6200
 * CEOL RCD-N8
@@ -45,7 +46,10 @@ Please let me know if your Denon model is supported.
 Most important features are implemented but there are some things that would be nice to have. If there is some demand for it these might be implemented until then the base functionality remains as is.
 * Zone2 control; channel select and volume.
 * Trigger cards.
-* More mobile control; volume and channel controls.
+* More mobile control; channel controls.
+
+#Version 1.0.1
+* Mobile control for volume
 
 #Version 1.0.0
 * Updated icon to be centered properly in app.

--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
                 "small": "drivers/com.moz.denon.driver/assets/images/small.png"
             },
             "class": "other",
-            "capabilities": [ "onoff" ],
+            "capabilities": [ "onoff", "volume_set", "volume_up", "volume_down", "volume_mute" ],
             "pair": [
                 {
                     "id": "start"

--- a/app.json
+++ b/app.json
@@ -8,12 +8,21 @@
         "en": "Control your Denon AVR with Homey."
     },
     "category": "appliances",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "compatibility": ">=1.5.0",
     "author": {
         "name": "Ralph Schaafsma",
         "email": "ralph.schaafsma@gmail.com"
     },
+    "contributors": {
+        "developers": [
+          {
+            "name": "Tim Kouters",
+            "email": "timkouters@gmail.com"
+          }
+        ]
+    },
+    "source": "https://github.com/murderbeard/com.moz.denon",
     "images": {
       "large": "./assets/images/large.png",
       "small": "./assets/images/small.png"


### PR DESCRIPTION
Hi,

I had some free time during the holidays.
I've added code for interacting with the Denon receivers from your mobile.
You now can:
 - Increase / decrease volume with a button
 - (Un)mute with a button
 - Set the volume with a slider.

Keep in mind this only works when your device is re-added after installing the new version of the app.
Otherwise the capability are not registered to the device instance you already had in Homey.

Kind regards,
Tim